### PR TITLE
Added NDCircularBuff plugin configuration

### DIFF
--- a/services/adsim_ioc/config/ioc.yaml
+++ b/services/adsim_ioc/config/ioc.yaml
@@ -150,3 +150,9 @@ entities:
     R: ":netCDF1:"
     NDARRAY_PORT: cam
 
+  - type: ADCore.NDCircularBuff
+    PORT: CB
+    P: XF:31IDA-BI{Cam:Tbl}
+    R: ":CB1:"
+    NDARRAY_PORT: cam
+


### PR DESCRIPTION
We must wait until [this PR](https://github.com/epics-containers/ibek-support/pull/93) is merged and a new image is released.

Alternatively, we can build and host our own image.