### PR TITLE
Bump adsimdetector container image version

### DIFF
--- a/services/adsim_ioc/compose.yml
+++ b/services/adsim_ioc/compose.yml
@@ -6,7 +6,7 @@ services:
       service: linux_ioc
       file: ../../include/ioc.yml
 
-    image: ghcr.io/epics-containers/ioc-adsimdetector-runtime:2025.3.5
+    image: ghcr.io/epics-containers/ioc-adsimdetector-runtime:2025.4.2b1
     platform: linux/amd64
     labels:
       version: 0.1.0


### PR DESCRIPTION
Needed for a fix for the `NDCiruclarBuffPlugin`.